### PR TITLE
Restructure search query response to use images

### DIFF
--- a/frontend/src/components/eco/speciesSearch.tsx
+++ b/frontend/src/components/eco/speciesSearch.tsx
@@ -3,29 +3,28 @@ import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { useApiQuery } from "@/lib/api";
+import SpeciesSearchResultRow from "./speciesSearchResultRow";
+import { kingdoms } from "@/lib/eco/kingdoms";
 
-interface TaxonomicTree {
-    kingdom?: string;
-    phylum?: string;
-    class?: string;
-    order?: string;
-    family?: string;
-    genus?: string;
-    species?: string;
+interface SpeciesSearchResult {
+    scientificName: string;
+    kingdom: string | null;
     vernacularNames: string[];
+    imageUrl: string | null;
 }
 
 interface SpeciesSearchResponse {
-    results: TaxonomicTree[];
+    results: SpeciesSearchResult[];
 }
 
 export default function SpeciesSearch() {
     const [searchQuery, setSearchQuery] = useState("");
     const [submittedQuery, setSubmittedQuery] = useState("");
-    const [kingdomFilter, setKingdomFilter] = useState("animalia");
+    const [kingdom, setKingdom] = useState("animalia");
+    const [submittedKingdom, setSubmittedKingdom] = useState("animalia");
 
     const { data, isLoading, error } = useApiQuery<SpeciesSearchResponse>(
-        `/species?query=${encodeURIComponent(submittedQuery)}&kingdom=${encodeURIComponent(kingdomFilter)}`,
+        `/species?query=${encodeURIComponent(submittedQuery)}&kingdom=${encodeURIComponent(submittedKingdom)}`,
         { enabled: !!submittedQuery } as any
     );
 
@@ -33,60 +32,39 @@ export default function SpeciesSearch() {
         e.preventDefault();
         if (searchQuery.trim()) {
             setSubmittedQuery(searchQuery.trim());
+            setSubmittedKingdom(kingdom);
         }
     };
 
-    const getKingdomColor = (kingdom?: string) => {
-        switch (kingdom?.toLowerCase()) {
-            case 'animalia':
-                return 'bg-blue-500 text-white';
-            case 'plantae':
-                return 'bg-green-500 text-white';
-            case 'fungi':
-                return 'bg-orange-500 text-white';
-            case 'bacteria':
-                return 'bg-purple-500 text-white';
-            case 'archaea':
-                return 'bg-pink-500 text-white';
-            case 'protista':
-                return 'bg-teal-500 text-white';
-            case 'chromista':
-                return 'bg-yellow-600 text-white';
-            default:
-                return 'bg-gray-500 text-white';
-        }
-    };
+    const selectedKingdom = kingdoms.find(k => k.value === kingdom) || kingdoms[0];
 
     return (
         <div className="min-h-screen flex items-center justify-center bg-background p-4">
-            <Card className="w-full max-w-4xl">
+            <Card className="w-full max-w-3xl">
                 <CardHeader>
                     <CardTitle className="text-center">Species Search</CardTitle>
                 </CardHeader>
                 <CardContent>
                     <form onSubmit={handleSearch} className="space-y-4">
                         <div className="flex gap-2">
+                            <select
+                                value={kingdom}
+                                onChange={(e) => setKingdom(e.target.value)}
+                                className={`px-3 py-2 border border-input rounded-md text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 text-white font-medium ${selectedKingdom.color}`}
+                            >
+                                {kingdoms.map(k => (
+                                    <option key={k.value} value={k.value}>
+                                        {k.label}
+                                    </option>
+                                ))}
+                            </select>
                             <Input
                                 type="text"
-                                placeholder="Search for a species! (e.g., lion, eagle, dolphin)"
+                                placeholder="Search species by scientific or common name"
                                 value={searchQuery}
                                 onChange={(e) => setSearchQuery(e.target.value)}
                                 className="flex-1"
                             />
-                            <select
-                                value={kingdomFilter}
-                                onChange={(e) => setKingdomFilter(e.target.value)}
-                                className="px-3 py-2 border border-input bg-background rounded-md text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
-                            >
-                                <option value="all">All Kingdoms</option>
-                                <option value="animalia">Animalia</option>
-                                <option value="plantae">Plantae</option>
-                                <option value="fungi">Fungi</option>
-                                <option value="bacteria">Bacteria</option>
-                                <option value="archaea">Archaea</option>
-                                <option value="protista">Protista</option>
-                                <option value="chromista">Chromista</option>
-                            </select>
                             <Button type="submit" disabled={isLoading || !searchQuery.trim()}>
                                 {isLoading ? "Searching..." : "Search"}
                             </Button>
@@ -94,72 +72,37 @@ export default function SpeciesSearch() {
                     </form>
 
                     {error && (
-                        <div className="mt-4 p-4 bg-red-100 dark:bg-red-900 text-red-800 dark:text-red-200 rounded">
+                        <div className="mt-4 p-4 bg-red-100 dark:bg-red-900 text-red-800 dark:text-red-200 rounded-md">
                             Error loading species data
                         </div>
                     )}
 
                     {submittedQuery && !isLoading && data && (
                         <div className="mt-6">
-                            <h3 className="text-lg font-semibold mb-3">
-                                Results for "{submittedQuery}": {data.results?.length || 0} species found
-                            </h3>
+                            <div className="text-sm text-muted-foreground mb-3">
+                                {data.results?.length || 0} {data.results?.length === 1 ? 'result' : 'results'} for "{submittedQuery}"
+                                {submittedKingdom !== "all" && (
+                                    <span className="ml-1">
+                                        in {kingdoms.find(k => k.value === submittedKingdom)?.label}
+                                    </span>
+                                )}
+                            </div>
                             {data.results && data.results.length > 0 ? (
-                                <div className="space-y-4">
-                                    {data.results.map((tree, index) => (
-                                        <Card key={index} className="p-4">
-                                            <div className="space-y-2">
-                                                <div className="flex items-center gap-2 flex-wrap">
-                                                    <span className={`px-2 py-1 rounded text-xs font-semibold ${getKingdomColor(tree.kingdom)}`}>
-                                                        {tree.kingdom || "Unknown"}
-                                                    </span>
-                                                    <span className="font-bold text-lg">{tree.species}</span>
-                                                    {tree.vernacularNames.length > 0 && (
-                                                        <span className="text-sm text-muted-foreground">
-                                                            ({tree.vernacularNames.join(", ")})
-                                                        </span>
-                                                    )}
-                                                </div>
-                                                <div className="text-sm text-muted-foreground space-y-1">
-                                                    {tree.phylum && (
-                                                        <div className="flex gap-2">
-                                                            <span className="font-semibold min-w-20">Phylum:</span>
-                                                            <span>{tree.phylum}</span>
-                                                        </div>
-                                                    )}
-                                                    {tree.class && (
-                                                        <div className="flex gap-2">
-                                                            <span className="font-semibold min-w-20">Class:</span>
-                                                            <span>{tree.class}</span>
-                                                        </div>
-                                                    )}
-                                                    {tree.order && (
-                                                        <div className="flex gap-2">
-                                                            <span className="font-semibold min-w-20">Order:</span>
-                                                            <span>{tree.order}</span>
-                                                        </div>
-                                                    )}
-                                                    {tree.family && (
-                                                        <div className="flex gap-2">
-                                                            <span className="font-semibold min-w-20">Family:</span>
-                                                            <span>{tree.family}</span>
-                                                        </div>
-                                                    )}
-                                                    {tree.genus && (
-                                                        <div className="flex gap-2">
-                                                            <span className="font-semibold min-w-20">Genus:</span>
-                                                            <span>{tree.genus}</span>
-                                                        </div>
-                                                    )}
-                                                </div>
-                                            </div>
-                                        </Card>
+                                <div className="border rounded-lg divide-y">
+                                    {data.results.map((species, index) => (
+                                        <SpeciesSearchResultRow
+                                            key={index}
+                                            scientificName={species.scientificName}
+                                            kingdom={species.kingdom}
+                                            vernacularNames={species.vernacularNames}
+                                            imageUrl={species.imageUrl}
+                                        />
                                     ))}
                                 </div>
                             ) : (
-                                <p className="text-muted-foreground">
+                                <div className="text-center py-8 text-muted-foreground">
                                     No species found matching "{submittedQuery}"
-                                </p>
+                                </div>
                             )}
                         </div>
                     )}

--- a/frontend/src/components/eco/speciesSearchResultRow.tsx
+++ b/frontend/src/components/eco/speciesSearchResultRow.tsx
@@ -1,0 +1,68 @@
+import { getKingdomColor } from "@/lib/eco/kingdoms";
+
+interface SpeciesSearchResultRowProps {
+    scientificName: string;
+    kingdom: string | null;
+    vernacularNames: string[];
+    imageUrl: string | null;
+}
+
+export default function SpeciesSearchResultRow({
+    scientificName,
+    kingdom,
+    vernacularNames,
+    imageUrl
+}: SpeciesSearchResultRowProps) {
+    return (
+        <div className="flex items-center gap-4 p-3 hover:bg-muted/50 rounded-lg transition-colors">
+            {/* Species Image */}
+            <div className="flex-shrink-0">
+                {imageUrl ? (
+                    <img
+                        src={imageUrl}
+                        alt={scientificName}
+                        className="w-20 h-20 object-cover rounded-md border border-border"
+                        onError={(e) => {
+                            e.currentTarget.src = 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80"><rect fill="%23ddd" width="80" height="80"/><text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="%23999" font-family="sans-serif" font-size="10">No Image</text></svg>';
+                        }}
+                    />
+                ) : (
+                    <div className="w-20 h-20 flex items-center justify-center bg-muted rounded-md border border-border">
+                        <svg
+                            className="w-8 h-8 text-muted-foreground"
+                            fill="none"
+                            stroke="currentColor"
+                            viewBox="0 0 24 24"
+                        >
+                            <path
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                strokeWidth={2}
+                                d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+                            />
+                        </svg>
+                    </div>
+                )}
+            </div>
+
+            {/* Species Info */}
+            <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2">
+                    {kingdom && (
+                        <span className={`px-2 py-0.5 rounded text-xs font-semibold text-white ${getKingdomColor(kingdom)}`}>
+                            {kingdom}
+                        </span>
+                    )}
+                    <div className="font-semibold text-base italic">
+                        {scientificName}
+                    </div>
+                </div>
+                {vernacularNames.length > 0 && (
+                    <div className="text-sm text-muted-foreground mt-0.5">
+                        {vernacularNames.join(", ")}
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/lib/eco/kingdoms.ts
+++ b/frontend/src/lib/eco/kingdoms.ts
@@ -1,0 +1,26 @@
+export interface Kingdom {
+    value: string;
+    label: string;
+    color: string;
+}
+
+export const kingdoms: Kingdom[] = [
+    { value: "all", label: "All Kingdoms", color: "bg-gray-500" },
+    { value: "animalia", label: "Animalia", color: "bg-blue-500" },
+    { value: "plantae", label: "Plantae", color: "bg-green-500" },
+    { value: "fungi", label: "Fungi", color: "bg-orange-500" },
+    { value: "bacteria", label: "Bacteria", color: "bg-purple-500" },
+    { value: "archaea", label: "Archaea", color: "bg-pink-500" },
+    { value: "protista", label: "Protista", color: "bg-teal-500" },
+    { value: "chromista", label: "Chromista", color: "bg-yellow-600" },
+];
+
+export const getKingdomColor = (kingdom?: string | null): string => {
+    const found = kingdoms.find(k => k.value.toLowerCase() === kingdom?.toLowerCase());
+    return found?.color || "bg-gray-500";
+};
+
+export const getKingdomLabel = (kingdom?: string | null): string => {
+    const found = kingdoms.find(k => k.value.toLowerCase() === kingdom?.toLowerCase());
+    return found?.label || kingdom || "Unknown";
+};

--- a/server/Nautilus.Api/Application/Eco/Species/SpeciesModels.cs
+++ b/server/Nautilus.Api/Application/Eco/Species/SpeciesModels.cs
@@ -2,7 +2,15 @@ namespace Nautilus.Api.Application.Eco.Species;
 
 public class SpeciesSearchResponse
 {
-    public List<TaxonomicTree> Results { get; set; } = new();
+    public List<SpeciesSearchResult> Results { get; set; } = [];
+}
+
+public class SpeciesSearchResult
+{
+    public string ScientificName { get; set; } = string.Empty;
+    public string? Kingdom { get; set; }
+    public List<string> VernacularNames { get; set; } = [];
+    public string? ImageUrl { get; set; }
 }
 
 public class TaxonomicTree
@@ -14,5 +22,5 @@ public class TaxonomicTree
     public string? Family { get; set; }
     public string? Genus { get; set; }
     public string? Species { get; set; }
-    public List<string> VernacularNames { get; set; } = new();
+    public List<string> VernacularNames { get; set; } = [];
 }

--- a/server/Nautilus.Api/Infrastructure/Eco/EcoStoreMem.cs
+++ b/server/Nautilus.Api/Infrastructure/Eco/EcoStoreMem.cs
@@ -46,6 +46,7 @@ public class Species
 {
     public int Id { get; set; }
     public string ScientificName { get; set; } = default!;
+    public string? Kingdom { get; set; }
     public int GenusId { get; set; }
     public long? UsageKey { get; set; }
     public string? Authorship { get; set; }
@@ -70,6 +71,13 @@ public class SearchCache
     public DateTime CreatedAt { get; set; }
 }
 
+public class SpeciesImage
+{
+    public string ScientificName { get; set; } = default!;
+    public string? ImageUrl { get; set; }
+    public DateTime CachedAt { get; set; }
+}
+
 // Static in-memory store for ecological data
 public static class EcoStoreMem
 {
@@ -82,6 +90,7 @@ public static class EcoStoreMem
     public static Dictionary<int, Species> Species { get; } = new();
     public static Dictionary<Guid, TaxonCommonName> TaxonCommonNames { get; } = new();
     public static Dictionary<string, List<SearchCache>> SearchCache { get; } = new(StringComparer.OrdinalIgnoreCase);
+    public static Dictionary<string, SpeciesImage> SpeciesImages { get; } = new(StringComparer.OrdinalIgnoreCase);
 
     private static int _nextKingdomId = 1;
     private static int _nextPhylumId = 1;

--- a/server/Nautilus.Api/Infrastructure/Eco/GbifModels.cs
+++ b/server/Nautilus.Api/Infrastructure/Eco/GbifModels.cs
@@ -1,0 +1,110 @@
+using Nautilus.Api.Infrastructure.Shared;
+
+namespace Nautilus.Api.Infrastructure.Eco;
+
+/// <summary>
+/// DTOs for GBIF (Global Biodiversity Information Facility) API responses.
+/// </summary>
+/// 
+/// <summary>
+/// Root response object from GBIF species search API.
+/// </summary>
+internal class GbifResult
+{
+    public int Offset { get; set; }
+    public int Limit { get; set; }
+    public bool EndOfRecords { get; set; }
+    public List<GbifSpecies> Results { get; set; } = [];
+}
+
+/// <summary>
+/// Represents a species entry from GBIF API with taxonomic hierarchy.
+/// </summary>
+internal class GbifSpecies
+{
+    public int Key { get; set; }
+    public string? ScientificName { get; set; }
+    public string? CanonicalName { get; set; }
+    public string? Kingdom { get; set; }
+    public string? Phylum { get; set; }
+    public string? Class { get; set; }
+    public string? Order { get; set; }
+    public string? Family { get; set; }
+    public string? Genus { get; set; }
+    public string? Species { get; set; }
+    // GBIF returns vernacularNames as objects with vernacularName and language properties
+    public List<GbifVernacularName>? VernacularNames { get; set; }
+
+    /// <summary>
+    /// Normalizes scientific names to "genus species" format and merges duplicate records.
+    /// </summary>
+    public static List<GbifSpecies> PreprocessGbifSpecies(List<GbifSpecies> species)
+    {
+        var normalizedSpecies = new Dictionary<string, GbifSpecies>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var gbifSpecies in species)
+        {
+            // Normalize scientific name to "genus species" format
+            var scientificName = gbifSpecies.ScientificName ?? gbifSpecies.CanonicalName ?? string.Empty;
+            var normalizedName = EcoUtils.NormalizeScientificName(scientificName);
+
+            // Skip if name cannot be normalized to "genus species" format
+            if (normalizedName == null)
+                continue;
+
+            if (normalizedSpecies.TryGetValue(normalizedName, out var existing))
+            {
+                // Merge records - fill in missing data from new record
+                existing.Kingdom ??= gbifSpecies.Kingdom;
+                existing.Phylum ??= gbifSpecies.Phylum;
+                existing.Class ??= gbifSpecies.Class;
+                existing.Order ??= gbifSpecies.Order;
+                existing.Family ??= gbifSpecies.Family;
+                existing.Genus ??= gbifSpecies.Genus;
+                existing.Species ??= gbifSpecies.Species;
+
+                // Keep the first Key encountered
+                if (existing.Key == 0 && gbifSpecies.Key != 0)
+                    existing.Key = gbifSpecies.Key;
+            }
+            else
+            {
+                // Create a copy with normalized name
+                var normalized = new GbifSpecies
+                {
+                    Key = gbifSpecies.Key,
+                    ScientificName = normalizedName,
+                    CanonicalName = gbifSpecies.CanonicalName,
+                    Kingdom = gbifSpecies.Kingdom,
+                    Phylum = gbifSpecies.Phylum,
+                    Class = gbifSpecies.Class,
+                    Order = gbifSpecies.Order,
+                    Family = gbifSpecies.Family,
+                    Genus = gbifSpecies.Genus,
+                    Species = gbifSpecies.Species,
+                    VernacularNames = gbifSpecies.VernacularNames
+                };
+                normalizedSpecies[normalizedName] = normalized;
+            }
+        }
+
+        return [.. normalizedSpecies.Values];
+    }
+}
+
+/// <summary>
+/// Root response object from GBIF vernacular names API.
+/// </summary>
+internal class GbifVernacularResult
+{
+    public List<GbifVernacularName> Results { get; set; } = [];
+}
+
+/// <summary>
+/// Represents a vernacular (common) name from GBIF with language information.
+/// </summary>
+internal class GbifVernacularName
+{
+    public string? VernacularName { get; set; }
+    public string? Language { get; set; }
+}

--- a/server/Nautilus.Api/Infrastructure/Eco/INaturalistModels.cs
+++ b/server/Nautilus.Api/Infrastructure/Eco/INaturalistModels.cs
@@ -1,0 +1,76 @@
+using System.Text.Json.Serialization;
+
+namespace Nautilus.Api.Infrastructure.Eco;
+
+/// <summary>
+/// DTOs for iNaturalist API responses.
+/// </summary>
+
+/// <summary>
+/// Root response object from iNaturalist taxa search API.
+/// </summary>
+internal class INaturalistResult
+{
+    [JsonPropertyName("total_results")]
+    public int TotalResults { get; set; }
+
+    [JsonPropertyName("page")]
+    public int Page { get; set; }
+
+    [JsonPropertyName("per_page")]
+    public int PerPage { get; set; }
+
+    [JsonPropertyName("results")]
+    public List<INaturalistTaxon> Results { get; set; } = [];
+}
+
+/// <summary>
+/// Represents a taxon entry from iNaturalist with associated photos.
+/// </summary>
+internal class INaturalistTaxon
+{
+    [JsonPropertyName("id")]
+    public int Id { get; set; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("rank")]
+    public string? Rank { get; set; }
+
+    [JsonPropertyName("preferred_common_name")]
+    public string? PreferredCommonName { get; set; }
+
+    [JsonPropertyName("default_photo")]
+    public INaturalistPhoto? DefaultPhoto { get; set; }
+
+    [JsonPropertyName("taxon_photos")]
+    public List<INaturalistTaxonPhoto>? TaxonPhotos { get; set; }
+}
+
+/// <summary>
+/// Represents a photo from iNaturalist API.
+/// </summary>
+internal class INaturalistPhoto
+{
+    [JsonPropertyName("id")]
+    public long Id { get; set; }
+
+    [JsonPropertyName("square_url")]
+    public string? SquareUrl { get; set; }
+
+    [JsonPropertyName("medium_url")]
+    public string? MediumUrl { get; set; }
+
+    [JsonPropertyName("url")]
+    public string? Url { get; set; }
+}
+
+/// <summary>
+/// Wrapper for taxon photo from iNaturalist API.
+/// </summary>
+internal class INaturalistTaxonPhoto
+{
+    [JsonPropertyName("photo")]
+    public INaturalistPhoto? Photo { get; set; }
+}

--- a/server/Nautilus.Api/Infrastructure/Eco/ISpeciesRepository.cs
+++ b/server/Nautilus.Api/Infrastructure/Eco/ISpeciesRepository.cs
@@ -4,5 +4,11 @@ namespace Nautilus.Api.Infrastructure.Eco;
 
 public interface ISpeciesRepository
 {
-    Task<List<TaxonomicTree>> SearchSpeciesAsync(string query, string? kingdom = null);
+    ///<summary>
+    /// Search species by query text (user input) and optional kingdom filter
+    ///</summary>
+    /// <param name="query"> The search query text entered by the user. </param>
+    /// <param name="kingdom"> Optional kingdom filter to narrow down the search results. </param>
+    /// <returns> A list of species search results matching the query and filter criteria. </returns>
+    Task<List<SpeciesSearchResult>> SearchSpeciesAsync(string query, string? kingdom = null);
 }

--- a/server/Nautilus.Api/Infrastructure/Eco/SpeciesRepositoryDB.cs
+++ b/server/Nautilus.Api/Infrastructure/Eco/SpeciesRepositoryDB.cs
@@ -10,7 +10,7 @@ public class SpeciesRepositoryDB : ISpeciesRepository
         // Initialize DB connection if needed
     }
 
-    public async Task<List<TaxonomicTree>> SearchSpeciesAsync(string query, string? kingdom = null)
+    public async Task<List<SpeciesSearchResult>> SearchSpeciesAsync(string query, string? kingdom = null)
     {
         // TODO: Implement actual DB query logic
         await Task.Delay(10);

--- a/server/Nautilus.Api/Infrastructure/Eco/TaxonomicTreeUtil.cs
+++ b/server/Nautilus.Api/Infrastructure/Eco/TaxonomicTreeUtil.cs
@@ -1,0 +1,164 @@
+using Nautilus.Api.Application.Eco.Species;
+
+namespace Nautilus.Api.Infrastructure.Eco;
+
+/// <summary>
+/// Utility class for building complete taxonomic trees from cached species data.
+/// </summary>
+public static class TaxonomicTreeUtil
+{
+    /// <summary>
+    /// Builds a complete taxonomic tree from a cached Species entity.
+    /// </summary>
+    public static TaxonomicTree BuildTaxonomicTree(Species species)
+    {
+        // Traverse hierarchy to build full taxonomic tree
+        var genus = EcoStoreMem.Genuses.TryGetValue(species.GenusId, out var g) ? g : null;
+        var family = genus != null && EcoStoreMem.Families.TryGetValue(genus.FamilyId, out var f) ? f : null;
+        var order = family != null && EcoStoreMem.Orders.TryGetValue(family.OrderId, out var o) ? o : null;
+        var classEntity = order != null && EcoStoreMem.Classes.TryGetValue(order.ClassId, out var c) ? c : null;
+        var phylum = classEntity != null && EcoStoreMem.Phylums.TryGetValue(classEntity.PhylumId, out var p) ? p : null;
+        var kingdom = phylum != null && EcoStoreMem.Kingdoms.TryGetValue(phylum.KingdomId, out var k) ? k : null;
+
+        var vernacularNames = EcoStoreMem.TaxonCommonNames.Values
+            .Where(tcn => tcn.SpeciesId == species.Id)
+            .Select(tcn => tcn.CommonName)
+            .ToList();
+
+        return new TaxonomicTree
+        {
+            Kingdom = kingdom?.Name,
+            Phylum = phylum?.Name,
+            Class = classEntity?.Name,
+            Order = order?.Name,
+            Family = family?.Name,
+            Genus = genus?.Name,
+            Species = species.ScientificName,
+            VernacularNames = vernacularNames
+        };
+    }
+
+
+    /// <summary>
+    /// Applies kingdom filtering and sorting using pre-calculated relevance scores.
+    /// </summary>
+    private static List<TaxonomicTree> ApplyKingdomFilterAndSort(
+        List<TaxonomicTree> trees,
+        Dictionary<TaxonomicTree, double> relevanceScores,
+        double minRelevanceScore,
+        string? kingdom)
+    {
+        // Normalize kingdom filter
+        var kingdomFilter = kingdom?.Trim().ToLowerInvariant();
+
+        // Filter by kingdom if specified
+        var filtered = trees;
+        if (!string.IsNullOrWhiteSpace(kingdomFilter) && kingdomFilter != "all")
+        {
+            filtered = [.. trees.Where(t => t.Kingdom != null && t.Kingdom.Equals(kingdom, StringComparison.OrdinalIgnoreCase))];
+        }
+
+        // Filter by minimum relevance score and sort
+        return [.. filtered
+            .Where(t => relevanceScores.TryGetValue(t, out var score) && score >= minRelevanceScore)
+            .OrderByDescending(t => relevanceScores.TryGetValue(t, out var score) ? score : 0)
+            .ThenBy(t => GetKingdomSortOrder(t.Kingdom))
+            .ThenBy(t => t.Species)];
+    }
+
+    /// <summary>
+    /// Returns sort order for kingdoms (lower number = higher priority).
+    /// </summary>
+    private static int GetKingdomSortOrder(string? kingdom)
+    {
+        return kingdom?.ToLowerInvariant() switch
+        {
+            "animalia" => 1,
+            "plantae" => 2,
+            "fungi" => 3,
+            "bacteria" => 4,
+            "archaea" => 5,
+            "protista" => 6,
+            "chromista" => 7,
+            _ => 99 // Unknown kingdoms go last
+        };
+    }
+
+
+    private static int GetOrCreateKingdom(string? name)
+    {
+        if (string.IsNullOrWhiteSpace(name)) name = "Unknown";
+
+        var existing = EcoStoreMem.Kingdoms.Values.FirstOrDefault(k => k.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+        if (existing != null) return existing.Id;
+
+        var id = EcoStoreMem.GetNextKingdomId();
+        EcoStoreMem.Kingdoms[id] = new Kingdom { Id = id, Name = name };
+        return id;
+    }
+
+    private static int GetOrCreatePhylum(string? name, int kingdomId)
+    {
+        if (string.IsNullOrWhiteSpace(name)) name = "Unknown";
+
+        var existing = EcoStoreMem.Phylums.Values.FirstOrDefault(p =>
+            p.Name.Equals(name, StringComparison.OrdinalIgnoreCase) && p.KingdomId == kingdomId);
+        if (existing != null) return existing.Id;
+
+        var id = EcoStoreMem.GetNextPhylumId();
+        EcoStoreMem.Phylums[id] = new Phylum { Id = id, Name = name, KingdomId = kingdomId };
+        return id;
+    }
+
+    private static int GetOrCreateClass(string? name, int phylumId)
+    {
+        if (string.IsNullOrWhiteSpace(name)) name = "Unknown";
+
+        var existing = EcoStoreMem.Classes.Values.FirstOrDefault(c =>
+            c.Name.Equals(name, StringComparison.OrdinalIgnoreCase) && c.PhylumId == phylumId);
+        if (existing != null) return existing.Id;
+
+        var id = EcoStoreMem.GetNextClassId();
+        EcoStoreMem.Classes[id] = new Class { Id = id, Name = name, PhylumId = phylumId };
+        return id;
+    }
+
+    private static int GetOrCreateOrder(string? name, int classId)
+    {
+        if (string.IsNullOrWhiteSpace(name)) name = "Unknown";
+
+        var existing = EcoStoreMem.Orders.Values.FirstOrDefault(o =>
+            o.Name.Equals(name, StringComparison.OrdinalIgnoreCase) && o.ClassId == classId);
+        if (existing != null) return existing.Id;
+
+        var id = EcoStoreMem.GetNextOrderId();
+        EcoStoreMem.Orders[id] = new Order { Id = id, Name = name, ClassId = classId };
+        return id;
+    }
+
+    private static int GetOrCreateFamily(string? name, int orderId)
+    {
+        if (string.IsNullOrWhiteSpace(name)) name = "Unknown";
+
+        var existing = EcoStoreMem.Families.Values.FirstOrDefault(f =>
+            f.Name.Equals(name, StringComparison.OrdinalIgnoreCase) && f.OrderId == orderId);
+        if (existing != null) return existing.Id;
+
+        var id = EcoStoreMem.GetNextFamilyId();
+        EcoStoreMem.Families[id] = new Family { Id = id, Name = name, OrderId = orderId };
+        return id;
+    }
+
+    private static int GetOrCreateGenus(string? name, int familyId)
+    {
+        if (string.IsNullOrWhiteSpace(name)) name = "Unknown";
+
+        var existing = EcoStoreMem.Genuses.Values.FirstOrDefault(g =>
+            g.Name.Equals(name, StringComparison.OrdinalIgnoreCase) && g.FamilyId == familyId);
+        if (existing != null) return existing.Id;
+
+        var id = EcoStoreMem.GetNextGenusId();
+        EcoStoreMem.Genuses[id] = new Genus { Id = id, Name = name, FamilyId = familyId };
+        return id;
+    }
+}

--- a/server/Nautilus.Api/Infrastructure/Shared/EcoUtils.cs
+++ b/server/Nautilus.Api/Infrastructure/Shared/EcoUtils.cs
@@ -1,0 +1,17 @@
+namespace Nautilus.Api.Infrastructure.Shared;
+
+public static class EcoUtils
+{
+    /// <summary>
+    /// Normalizes scientific names to "genus species" format.
+    /// </summary>
+    public static string NormalizeScientificName(string scientificName)
+    {
+        var parts = scientificName.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length >= 2)
+        {
+            return $"{parts[0]} {parts[1]}";
+        }
+        return scientificName;
+    }
+}

--- a/server/Nautilus.Api/appsettings.Development.json
+++ b/server/Nautilus.Api/appsettings.Development.json
@@ -1,7 +1,7 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Information",
+      "Default": "Debug",
       "Microsoft.AspNetCore": "Warning"
     }
   },


### PR DESCRIPTION
Now, instead of returning full taxonomic tree data, the search api returns: 
1. Scientific name
2. Vernacular name(s)
3. Kingdom
4. 1 image